### PR TITLE
New lagoSites.jsonld parser

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012, The LAGO Project
+Copyright (c) 2015, The LAGO Collaboration, https://lagoproject.net
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,50 @@
-#   Makefile   -- 
-#   Copyright (C) 2012-TODAY The LAGO Project, http://lagoproject.org, lago-pi@lagoproject.org
-#   Original authors: Hernán Asorey
-#   e-mail: asoreyh@cab.cnea.gov.ar  (asoreyh@gmail.com)
-#   Laboratorio de Detección de Partículas y Radiación (LabDPR)
-#   Centro Atómico Bariloche - San Carlos de Bariloche, Argentina 
-#
+# /************************************************************************/
+# /* Package:  ARTI                                                       */
+# /* Module:   Makefile 					                              */
+# /************************************************************************/
+# /* Authors:  Hernán Asorey                                              */
+# /* e-mail:   hernan.asoreyh@iteda.cnea.gov.ar                           */
+# /************************************************************************/
+# /* Comments: Compile the LAGO ARTI analysis tools                       */
+# /************************************************************************/
+# /*
 # LICENSE BSD-3-Clause
-# Copyright (c) 2012, The LAGO Project
+# Copyright (c) 2015
+# The LAGO Collaboration
+# https://lagoproject.net
 # All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-# 
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-# 
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-# 
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
-
-#   -*- coding: utf8 -*-
-#   try to preserve encoding  
-
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    1. Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+# NO EVENT SHALL LAB DPR OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are
+# those of the authors and should not be interpreted as representing
+# official policies, either expressed or implied, of Lab DPR.
+#
+# */
+# /************************************************************************/
+#
+VERSION="v1r9";
 CODE_DIR = analysis
 TESTS = check-lago 
 

--- a/lago-arti.sh
+++ b/lago-arti.sh
@@ -1,34 +1,26 @@
 #!/bin/bash
-#   lago-arti.sh 
-#	define LAGO_ARTI and modify .bashrc
-#   Copyright (C) 2012-TODAY The LAGO Project, http://lagoproject.org, lago-pi@lagoproject.org
-#   Original authors: Hernán Asorey
-#   e-mail: asoreyh@cab.cnea.gov.ar  (asoreyh@gmail.com)
-#   Laboratorio de Detección de Partículas y Radiación (LabDPR)
-#   Centro Atómico Bariloche - San Carlos de Bariloche, Argentina 
-#
+# /************************************************************************/
+# /* Package:  ARTI                                                       */
+# /* Module:   lago_arti.sh									                              */
+# /************************************************************************/
+# /* Authors:  Hernán Asorey                                              */
+# /* e-mail:   hernan.asoreyh@iteda.cnea.gov.ar                           */
+# /************************************************************************/
+# /* Comments: Configure environment variables for a fresh ARTI install   */
+# /************************************************************************/
+# /*
 # LICENSE BSD-3-Clause
-# Copyright (c) 2012, The LAGO Project
+# Copyright (c) 2015
+# The LAGO Collaboration
+# https://lagoproject.net
 # All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-# 
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-# 
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-# 
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
-
 #   -*- coding: utf8 -*-
-#   try to preserve encoding  
+VERSION="v1r9"
 export LAGO_ARTI=${PWD}
 date=$(date -u)
 echo "
 #
-## Changes added by the LAGO ARTI suite on $date
+## Changes added by the LAGO ARTI suite $VERSION on $date
 #
 export LAGO_ARTI=\"${LAGO_ARTI}\"
 export PATH=\"\${LAGO_ARTI}/sims/:\${LAGO_ARTI}/analysis:\$PATH\"

--- a/sims/do_sims.sh
+++ b/sims/do_sims.sh
@@ -47,10 +47,10 @@
 # 
 VERSION="v1r9";
 showhelp() {
-  echo 
   echo -e "$0 version $VERSION"
   echo 
   echo -e "USAGE $0:"
+  echo -e
   echo -e "Simulation parameters"
   echo -e "  -w <working dir>                   : Working directory, where bin (run) files are located"
   echo -e "  -p <project name>                  : Project name (suggested format: NAMEXX)"
@@ -58,6 +58,7 @@ showhelp() {
   echo -e "  -h <HE Int Model (EPOS|QGSII)>     : Define the high interaction model to be used"
   echo -e "  -u <user name>                     : User Name."
   echo -e "  -j <procs>                         : Number of processors to use"
+  echo -e
   echo -e "Physical parameters"
   echo -e "  -t <flux time>                     : Flux time (in seconds) for simulations"
   echo -e "  -m <Low edge zenith angle>         : Low edge of zenith angle."
@@ -66,13 +67,16 @@ showhelp() {
   echo -e "  -i <Upper primary particle energy> : Upper limit of the primary particle energy."
   echo -e "  -a <high energy ecuts>             : High energy cuts for ECUTS; (if set value in GV = enabled)."
   echo -e "  -y                                 : Select volumetric detector mode (default=flat array)"
+  echo -e
   echo -e "Site parameters"
   echo -e "  -s <site>                          : Location (several options)"
   echo -e "  -k <altitude, in cm>               : Fix altitude, even for predefined sites"
   echo -e "  -c <atm_model>                     : Fix Atmospheric Model even for predefined sites."
   echo -e "  -o <BX>                            : Horizontal comp. of the Earth's mag. field."
   echo -e "  -q <BZ>                            : Vertical comp. of the Earth's mag. field."
-  echo -e "  -b <rigidity cutoff>               : Rigidity cutoff; (if set value in GV = enabled)."
+  echo -e "  -b <rigidity cutoff>               : Rigidity cutoff; (if set value in GV = enabled, <0 = disable)."
+  echo -e "  -g <Lat, Lon> *dev                 : Obtain the current values of BX and BZ for a site located at (Lat,Lon,Alt), -k option is mandatory. If -s is used, then (Lat,Lon,Alt) will be taken from the standard characterization of the site."
+  echo -e
   echo -e "Modifiers"
   echo -e "  -l                                 : Enables SLURM cluster compatibility (with sbatch)."
   echo -e "  -e                                 : Enable CHERENKOV mode"
@@ -418,9 +422,8 @@ if $slurm; then
 fi
 
 rain="$rain -r $wdir -v $ver -h $hig -b $prj/\$i-*.run"
-
-echo -e "#  INFO   : rain command: $rain"
-
+# echo -e "#  INFO   : rain command: $rain"
+echo -e "#  INFO   : Calculations done. Now run the go_${prj}_* scripts in $wdir/"
 basenice=19
 if $slurm; then
   basenice=0;

--- a/sims/do_sims.sh
+++ b/sims/do_sims.sh
@@ -1,24 +1,18 @@
 #!/bin/bash
 # /************************************************************************/
-# /*                                                                      */
 # /* Package:  ARTI                                                       */
-# /* Module:   do_sims.sh										          */
-# /*                                                                      */
+# /* Module:   do_sims.sh										                              */
 # /************************************************************************/
 # /* Authors:  Hernán Asorey                                              */
-# /* e-mail:   asoreyh@cab.cnea.gov.ar                                    */
-# /*                                                                      */
+# /* e-mail:   hernan.asoreyh@iteda.cnea.gov.ar                           */
 # /************************************************************************/
-# /* Comments: Main script to automatize secondary flux calculations and  */
-# /*           run simulations in a single personal computer              */
-# /*                                                                      */
+# /* Comments: Main script to automatize secondary flux calculations      */
 # /************************************************************************/
-# /* 
-#  
-# Copyright 2017
-# Hernán Asorey
-# Lab DPR (CAB-CNEA), Argentina
-# Grupo Halley (UIS), Colombia
+# /*
+# LICENSE BSD-3-Clause
+# Copyright (c) 2015
+# The LAGO Collaboration
+# https://lagoproject.net
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -51,8 +45,7 @@
 # */
 # /************************************************************************/
 # 
-VERSION="v1r0"; # Tue Aug  6 15:43:52 COT 2013
-
+VERSION="v1r9";
 showhelp() {
   echo 
   echo -e "$0 version $VERSION"
@@ -316,7 +309,7 @@ fi
 if $highsec; then
 	echo -e "#  WARNING: High energy cuts of $ecut GeV for secondaries will be used."
 	if [ $lowppe -lt $ecut ]; then
-			lowppe="$ecut"
+			lowppe=$ecut
 			lppe=true
 			echo -e "#  WARNING: Primary particle low energy limit is below energy cuts for secondaries. Changing to: $lowppe"
 	fi
@@ -325,7 +318,6 @@ fi
 if $slurm; then
 	echo -e "#  WARNING: SLURM mode is enable. Will not work in other environments."
 fi
-
 
 corsika_bin="corsika${ver}Linux_${hig}_gheisha"
 if [ ! -e $wdir/$corsika_bin ]; then

--- a/sims/generate_spectra.pl
+++ b/sims/generate_spectra.pl
@@ -8,7 +8,7 @@
 # /************************************************************************/
 # /************************************************************************/
 # /* Comments: Simple meta script to generate input files from spectrum   */
-# /*           for all nuclei (data is read from genEspectra.dat)         */
+# /*           for all nuclei (data is read from spectra.dat)             */
 # /************************************************************************/
 # /*
 # LICENSE BSD-3-Clause
@@ -49,6 +49,9 @@
 #
 use strict;
 use warnings;
+use LWP::Simple;
+use JSON;
+
 my $VERSION="v1r9";
 
 # defaults
@@ -83,7 +86,6 @@ my $altitude=0.;
 my $bx=0.;
 my $bz=0.;
 
-
 # masses from stderr output of mass.pl
 my @mid = (0, 14, 402, 703, 904, 1105, 1206, 1407, 1608, 1909, 2010, 2311, 2412, 2713, 2814, 3115, 3216, 3517, 3919, 4018, 4020, 4521, 4822, 5123, 5224, 5525, 5626);
 my @mms = (0., 0.938272, 3.73338244805557, 6.53478032991106, 8.39429044902688, 10.2536061929541, 11.1787903246739, 13.045071978869, 14.898326507629, 17.6899146520668, 18.6173579550734, 21.4080199431823, 22.3362803688324, 25.1263356296296, 26.0553153433303, 28.8449660324983, 29.7745989328225, 32.5639816988633, 36.2834316370329, 37.2107457840596, 37.2142385732562, 41.8605295331555, 44.6483661801865, 47.4401999906342, 48.3681334024753, 51.1598095147594, 52.0885229269484);
@@ -92,7 +94,7 @@ for (my $i=0; $i<@mid; $i++) {
   $mass {$mid[$i]} = $mms[$i];
 }
 
-sub get {
+sub get_answer {
     my $question = $_[0];
     my $default = $_[1];
     my $param = $_[2];
@@ -102,21 +104,14 @@ sub get {
         chomp (my $tmp = <STDIN>);
         $var = $tmp;
     }
-    $var = $default if (!defined $var);
-    print "Fixed param: $param $var\n";
+    $var = $default unless ($var);
+    print "Fixed param: $param $var\n\n" if ($batch == 0);
     return $var;
 }
 
 my $help="
-
 $0 $VERSION
-
-A simple meta script to generate input files (through rain.pl)
-for a complete set of nuclei to define the complete spectra
-Read spectra data from file spectra.dat unless other provided 
-(C) 2022 - H. Asorey
-
-Usage: $0 options
+Usage: $0 options\n
 
 Mandatory:
   -w <working dir>      Where CORSIKA run files are located
@@ -124,7 +119,7 @@ Mandatory:
 Recommended:
   -f <file>             Use file to calculate nuclei spectra, assuming a flux of the form:
                              j(E) = j0 * E^(-gamma), where j0=a0 x 10^-e0.
-                        Format (See genspectra.dat):
+                        Format (See spectra.dat):
                           - First line: number of nuclei to process. 
                           - Then, for each nuclei 4 lines should be included:
                              1) CORSIKA particle id
@@ -243,16 +238,16 @@ while (defined($_ = $ARGV[0]) && $_ =~ /^-/) {
 }
 
 # Asking for options
-print STDERR "\n### GENERATE SPECTRA ###\n\n\n";
-$file=get("Spectra file","","(file)",$file);
+print STDERR "### INTEGRATING PRIMARY SPECTRA ###\n\n";
+$file = get_answer("Spectra file", "spectra.dat", "(file)", $file);
 print STDERR "\n### Project parameters ###\n\n" unless ($time && $wdir && $prj);
-$prj=get("Project name","","(prj)",$prj);
-$wdir=get("Project parent dir","","(wdir)",$wdir);
-$time=get("Flux time [s] ",3600,"(time)", $time);
+$prj = get_answer("Project name", "sim",  "(prj)", $prj);
+$wdir = get_answer("Project parent dir", ".", "(wdir)", $wdir);
+$time = get_answer("Flux time [s]", 3600, "(time)", $time);
 my $direct="$wdir/$prj";
 my $home = $wdir;
 
-$user=get("User ORCID or local user","","(user)",$user);
+$user=get_answer("User ORCID or local user","","(user)",$user);
 if ($cluster != 0) {
     $wdir="/opt/corsika-73500/run";
     $user=$clsname;
@@ -261,253 +256,78 @@ if ($cluster != 0) {
 }
 
 print STDERR "\n### Shower parameters ###\n\n" unless ($usedefaults != 0);
-$tMin = get("Low edge of zenith angle (THETAP) [deg]", 0, "THETPR(1)", $tMin);
-$tMax = get("High edge of zenith angle (THETAP) [deg]", 90, "THETPR(2)", $tMax);
-$llimit = get("Lower limit of the primary particle energy (ERANGE) [GeV]", 5e0, "LLIMIT", $llimit);
-$ulimit = get("Upper limit of the primary particle energy (ERANGE) [GeV]", 1e6, "ULIMIT", $ulimit);
-print STDERR "\n### Site parameters ###\n\n" unless ($rigidity && $modatm);
-$rigidity = get("Use rigidity cutoff? (0=no, Rigidity value=yes [GV])",5.,"", $rigidity);
+$tMin = get_answer("Low edge of zenith angle (THETAP) [deg]", 0, "THETPR(1)", $tMin);
+$tMax = get_answer("High edge of zenith angle (THETAP) [deg]", 90, "THETPR(2)", $tMax);
+$llimit = get_answer("Lower limit of the primary particle energy (ERANGE) [GeV]", 2e0, "LLIMIT", $llimit);
+$ulimit = get_answer("Upper limit of the primary particle energy (ERANGE) [GeV]", 1e6, "ULIMIT", $ulimit);
+if ($batch == 0) {
+    print STDERR "### Site parameters ###\n\n" unless ($rigidity && $modatm);
+}
+$rigidity = get_answer("Use rigidity cutoff? (no: <0; yes: Rigidity value [GV])", 5., "rigidity", $rigidity);
+$rigidity = 0. if ($rigidity < 0);
 my $userllimit=$llimit;
 #all predefined sites seems to be ATMOSPHERE as default mode
 my $atmcrd = "ATMOSPHERE";
 
-if ($site eq "sawb") {
-    $modatm="E5";
-    $altitude=20000;
-    $bx=19.366;
-    $bz=-30.222;
-} elsif ($site eq "mapi") {
-    $modatm="E5";
-    $altitude=1000;
-    $bx=19.309;
-    $bz=-28.693;
-} elsif ($site eq "brc") {
-    $modatm="E3";
-    $altitude=86500;
-    $bx=18.952;
-    $bz=-17.05;
-} elsif ($site eq "bue") {
-    $modatm="E2";
-    $altitude=1000;
-    $bx=17.09;
-    $bz=-14.673;
-} elsif ($site eq "kna") {
-    $modatm="E2";
-    $altitude=34700;
-    $bx=19.56;
-    $bz=-13.333;
-} elsif ($site eq "lsc") {
-    $modatm="E2";
-    $altitude=2800;
-    $bx=19.975;
-    $bz=-11.826;
-} elsif ($site eq "tuc") {
-    $modatm="E2";
-    $altitude=43000;
-    $bx=19.487;
-    $bz=-10.647;
-} elsif ($site eq "asu") {
-    $modatm="E1";
-    $altitude=13600;
-    $bx=18.233;
-    $bz=-11.73;
-} elsif ($site eq "sao") {
-    $modatm="E1";
-    $altitude=76000;
-    $bx=16.484;
-    $bz=-14.48;
-} elsif ($site eq "vcp") {
-    $modatm="E1";
-    $altitude=64000;
-    $bx=16.751;
-    $bz=-14.104;
-} elsif ($site eq "lpb") {
-    $modatm="E2";
-    $altitude=363000;
-    $bx=22.362;
-    $bz=-4.708;
-} elsif ($site eq "cha") {
-    $modatm="E2";
-    $altitude=523000;
-    $bx=22.38;
-    $bz=-4.62;
-} elsif ($site eq "cuz") {
-    $modatm="E1";
-    $altitude=340000;
-    $bx=23.676;
-    $bz=-2.02;
-} elsif ($site eq "lim") {
-    $modatm="E1";
-    $altitude=16800;
-    $bx=24.723;
-    $bz=-0.476;
-} elsif ($site eq "cpv") {
-    $modatm="E1";
-    $altitude=55000;
-    $bx=21.174;
-    $bz=-12.612;
-} elsif ($site eq "serb") {
-    $modatm="E1";
-    $altitude=275000;
-    $bx=26.577;
-    $bz=8.499;
-} elsif ($site eq "quie") {
-    $modatm="E1";
-    $altitude=285000;
-    $bx=26.717;
-    $bz=9.971;
-} elsif ($site eq "bga") {
-    $modatm="E1";
-    $altitude=95000;
-    $bx=26.793;
-    $bz=16.055;
-} elsif ($site eq "pam") {
-    $modatm="E1";
-    $altitude=234200;
-    $bx=26.743;
-    $bz=15.955;
-} elsif ($site eq "gua") {
-    $modatm="E1";
-    $altitude=149000;
-    $bx=27.532;
-    $bz=24.932;
-} elsif ($site eq "tac") {
-    $modatm="E1";
-    $altitude=406000;
-    $bx=27.53;
-    $bz=25.353;
-} elsif ($site eq "chia") {
-    $modatm="E2";
-    $altitude=52200;
-    $bx=27.405;
-    $bz=27.024;
-} elsif ($site eq "chi") {
-    $modatm="E1";
-    $altitude=500000;
-    $bx=26.56;
-    $bz=8.758;
-} elsif ($site eq "sng") {
-    $modatm="E2";
-    $altitude=455000;
-    $bx=27.358;
-    $bz=28.038;
-} elsif ($site eq "and") {
-    $modatm="E2";
-    $altitude=420000;
-    $bx=19.658;
-    $bz=-11.951;
-} elsif ($site eq "mge") {
-    $modatm="E2";
-    $altitude=145000;
-    $bx=18.987;
-    $bz=-14.326;
-} elsif ($site eq "ber") {
-    $modatm="E1";
-    $altitude=345000;
-    $bx=26.751;
-    $bz=16.029;
-} elsif ($site eq "sac") {
-    $modatm="E2";
-    $altitude=482000;
-    $bx=20.06;
-    $bz=-9.616;
-} elsif ($site eq "cop") {
-    $modatm="E2";
-    $altitude=200000;
-    $bx=19.04;
-    $bz=-15.493;
-} elsif ($site eq "sgd") {
-    $modatm="E2";
-    $altitude=25000;
-    $bx=18.108;
-    $bz=-16.891;
-} elsif ($site eq "casp") {
-    $modatm="E2";
-    $altitude=260000;
-    $bx=19.473;
-    $bz=-12.436;
-} elsif ($site eq "ppet") {
-    $modatm="E2";
-    $altitude=350000;
-    $bx=19.139;
-    $bz=-14.27;
-} elsif ($site eq "mad") {
-    $modatm="E2";
-    $altitude=70000;
-    $bx=25.647;
-    $bz=36.933;
-} elsif ($site eq "truj") {
-    $modatm="E2";
-    $altitude=56000;
-    $bx=26.223;
-    $bz=35.844;
-} elsif ($site eq "pozn") {
-    $modatm="E2";
-    $altitude=10000;
-    $bx=18.598;
-    $bz=46.45;
-} elsif ($site eq "juli") {
-    $modatm="E2";
-    $altitude=10000;
-    $bx=19.676;
-    $bz=44.928;
-} elsif ($site eq "sudb") {
-    $modatm="E2";
-    $altitude=210000;
-    $bx=17.037;
-    $bz=51.991;
-} elsif ($site eq "viri") {
-    $modatm="E2";
-    $altitude=285000;
-    $bx=19.061;
-    $bz=-16.289;
-} elsif ($site eq "ima") {
-    $modatm="E1";
-    $altitude=460000;
-    $bx=22.969;
-    $bz=-3.79;
-} elsif ($site eq "ata") {
-    $modatm="E1";
-    $altitude=510500;
-    $bx=20.638;
-    $bz=-8.598;
-} elsif ($site eq "gen") {
-    $gensite=1;
-} elsif ($site eq "air") {
-    $gensite=1;
-} elsif ($site eq "unk") {
-    $gensite=1;
+if ($site ne "unk") {
+    # first, read the jsonld and build the sites hash
+    my $url = "https://lagoproject.github.io/DMP/defs/sitesLago.jsonld";
+    my $jsonld;
+    die "could not get $url\n" unless (defined($jsonld = get $url));
+    my $decoded = decode_json($jsonld);
+    my @sites_json = @{$decoded->{'@graph'}};
+    my %sites = ();
+    foreach my $s (@sites_json) {
+        $sites{ $s->{'@id'} } = [
+            $s->{'lago:atmcrd'}{'lago:modatm'}{'@default'},
+            $s->{'lago:obsLev'}{'@default'},
+            $s->{'lago:magnet'}{'@default'}{'lago:bx'},
+            $s->{'lago:magnet'}{'@default'}{'lago:bz'}
+        ]; # 0: atm; 1: obslev(cm); 2: bx; 3: bz;
+    }
+    # second, check if
+    if (defined $sites{"$site"}) {
+        $modatm = $sites{"$site"}[0];
+        $altitude = $sites{"$site"}[1];
+        $bx = $sites{"$site"}[2];
+        $bz = $sites{"$site"}[3];
+    } else {
+        if ($site eq "gen" || $site eq "air" || $site eq "unk") {
+            print STDERR "WARNING: $site is generic. Some defaults needs to be used\n";
+            $gensite = 1;
+        }
+        else { # completely unknown site. print a warning and go for unk
+            print STDERR "WARNING: $site is unknown. Back to manual selection\n";
+            $site = "unk";
+        }
+    }
 }
 
-unless ($ifixmodatm) {
-    $modatm = get("Atmospheric model selection (ATMOD). Start number with 'E' to use external atmospheres module (ATMOSPHERE), examples: E30=wi,E31=sp,E32=su,E33=au)", $modatm, "$atmcrd", $modatm);
+unless ($ifixmodatm != 0) {
+    $modatm = get_answer(
+        "Atmospheric model selection (ATMOD). Start number with 'E' to use external atmospheres module (ATMOSPHERE), examples: E1, E2)", $modatm, "$atmcrd", $modatm
+    );
+    die "ERROR: missing atmospheric profile selection\n" if ($modatm eq "");
 }
 
-unless ($ifixalt) {
-    while (!$altitude) {
-        $altitude = get("Observation level above sea level [cm]",0,"OBSLEV", $altitude);
-		if (!$altitude) { die "ERROR: Observation level is mandatory > 0\n"; }
-      }
+unless ($ifixalt != 0) {
+    while ($altitude == 0) {
+        $altitude = get_answer("Observation level above sea level [cm]",0,"OBSLEV", $altitude);
+		if ($altitude == 0) { die "ERROR: Observation level is mandatory > 0\n"; }
+    }
 }
 
-while (!$bx) {
-    $bx=get("Horizontal comp. of the Earth's mag. field (MAGNET) [North,muT],\nsee values at http://www.ngdc.noaa.gov/geomagmodels/struts/calcIGRFWMM",0,"BX", $bx);
-	if (!$bx) { die "ERROR: BX is mandatory\n"; }
+while ($bx == 0) {
+    $bx=get_answer("Horizontal comp. of the Earth's mag. field (MAGNET) [North,muT],\nsee values at http://www.ngdc.noaa.gov/geomagmodels/struts/calcIGRFWMM",0,"BX", $bx);
+    die "ERROR: BX is mandatory\n" if ($bx == 0);
 }
-
-while (!$bz) {
-    $bz=get("Vertical comp. of the Earth's mag. field (MAGNET) [downwards,muT]",0,"BZ", $bz);
-	if (!$bz) { die "ERROR: BZ is mandatory\n"; }
+while ($bz == 0) {
+    $bz=get_answer("Vertical comp. of the Earth's mag. field (MAGNET) [downwards,muT]",0,"BZ", $bz);
+    die "ERROR: BZ is mandatory\n" if ($bz == 0);
 }
-
-if ($ifixalt && $fixalt) {
-  $altitude=$fixalt;
-}
-if ($ifixmodatm && $fixmodatm) {
-  $modatm=$fixmodatm;
-}
-
-if ($gensite) { 
+$altitude = $fixalt if ($ifixalt && $fixalt);
+$modatm = $fixmodatm if ($ifixmodatm && $fixmodatm);
+if ($gensite != 0) {
 	unless ($modatm ne "" && $bx && $bz && $altitude) {
 		die "ERROR: For generic sites, altitude (-k), atmospheric model (-c) and geomagnetic coordinates (-o, -q) are mandatory\n"; 
 	}
@@ -518,7 +338,6 @@ if ($gensite) {
 ######################################################
 ### You should not modify anything below this line ###
 ######################################################
-
 opendir(IMD, "$direct/") or system("mkdir -p $direct");
 opendir(IMD, "$direct/") or die ("ERROR: Can't open directory $direct\n");
 closedir(IMD);
@@ -549,11 +368,11 @@ my @nuc = ("", "H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na", "Mg",
 my $mass_0 = 0.;
 my %spc = ();
 my $totalShowers = 0;
-print "Number of nucleus?:";
+# print "Number of nucleus?:";
 chomp ($N_prim=<$fh>);
 for (my $i = 0; $i < $N_prim; $i++) {
 # Reading spectra data from file
-  print "Nucleus?: ";
+  # # print "Nucleus?: ";
   chomp ($id = <$fh>);
   if ($id == 14) {
     $Z = 1;
@@ -563,12 +382,12 @@ for (my $i = 0; $i < $N_prim; $i++) {
     $A = int ($id / 100);
     $Z = $id - $A * 100;
   }
-  print "j0? (mantissa) : ";
+  # print "j0? (mantissa) : ";
   chomp ($mantissa = <$fh>);
   $mantissa *= 1.;
-  print "e0? (exponent>0) : ";
+  # print "e0? (exponent>0) : ";
   chomp ($exponent=(<$fh>) * -1);
-  print "Gamma (>0)?: ";
+  # print "Gamma (>0)?: ";
   chomp ($gamma=(<$fh>) * -1);
   $alpha = (1. + $gamma);
   $j0 = $mantissa * 10**$exponent;
@@ -584,10 +403,10 @@ for (my $i = 0; $i < $N_prim; $i++) {
   my $E_reference = 1000.;  # 1 TeV
   $N_show = int($N * ($j0 / $alpha) * (($ulimit / $E_reference)**$alpha - ($llimit / $E_reference)**$alpha));
   $N_show = 1 if ($N_show == 0);
-  while (defined(${$N_show})) {
+  while (defined($spc{$N_show})) {
     $N_show++;
   }
-  $spc{$N_show} = "$A $Z $nuc[$Z] $mass{$id} $llimit $N_show";
+  $spc{$N_show} = "$A $Z $nuc[$Z] $N_show $llimit";
   $totalShowers += $N_show;
   #generating input files
   my $filename = sprintf("%06d-%011d.run", $id, $N_show);
@@ -632,8 +451,10 @@ my $hig=", standard energy cuts";
 $hig = ", high energy cuts at $ecut GeV" if ($highsec > 0);
 
 open ($fh, "> $file") or die "Can't open file $direct/$file\n";
-print $fh "Flux time: $time s ($totalShowers showers, $userllimit<E<$ulimit, $tMin<q<$tMax at site $site (h=$altitude, atm=$modatm)yy$vol$hig$rig\n";
-print $fh "$spc{$_}\n" foreach (sort {$b <=> $alpha} keys %spc);
+print $fh "Flux time: $time s ($totalShowers showers, $userllimit<E<$ulimit, $tMin<q<$tMax at site $site (h=$altitude, atm=$modatm)$vol$hig$rig\n";
+print $fh "\nA Z X N_prim E_min\n";
+print $fh "----------------------------\n";
+print $fh "$spc{$_}\n" foreach (sort {$b <=> $a} keys %spc);
 close($fh);
 print"\n";
-system ("echo; echo; echo 'Fluxes'; cat $file");
+system ("cat $file");

--- a/sims/mass.pl
+++ b/sims/mass.pl
@@ -1,25 +1,20 @@
 #!/usr/bin/perl -w
 # /************************************************************************/
-# /*                                                                      */
 # /* Package:  ARTI                                                       */
 # /* Module:   mass.pl                                                    */
-# /*                                                                      */
 # /************************************************************************/
 # /* Authors:  Hernán Asorey                                              */
-# /* e-mail:   asoreyh@cab.cnea.gov.ar                                    */
-# /*                                                                      */
+# /* e-mail:   hernan.asoreyh@iteda.cnea.gov.ar                           */
 # /************************************************************************/
-# /* Comments: Calculate atomic mases using semiempirical mass formula.   */
-# /*                                                                      */
+# /* Comments: Calculate nuclei masses using the semi-empirical mass      */
 # /************************************************************************/
-# /* 
-#  
-# Copyright 2013
-# Hernán Asorey
-# Lab DPR (CAB-CNEA), Argentina
-# Grupo Halley (UIS), Colombia
+# /*
+# LICENSE BSD-3-Clause
+# Copyright (c) 2015
+# The LAGO Collaboration
+# https://lagoproject.net
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met:
@@ -51,22 +46,24 @@
 # /************************************************************************/
 #
 
-$VERSION="v1r0";
+use strict;
+use warnings;
+my $VERSION="v1r9";
 
-$cv = 15.85;
-$cs = 18.34;
-$cc =  0.71;
-$ca = 23.21;
-$cp = 12.00;
-
-$mn = 939.565;
-$mp = 938.272;
-
-$Bfsm = $masa = 0.;
-
-%masas = (); 
-
-$tmp = <>; # discard first line
+my $cv = 15.85;
+my $cs = 18.34;
+my $cc =  0.71;
+my $ca = 23.21;
+my $cp = 12.00;
+my $mn = 939.565;
+my $mp = 938.272;
+my $BFSM = 0.;
+my $mass = 0.;
+my $id = 0;
+my %masses = ();
+my $tmp = <>; # discard first line
+my $A = 0;
+my $Z = 0;
 
 while (<>) {
   chomp;
@@ -75,39 +72,43 @@ while (<>) {
   $tmp = <>;
   $tmp = <>;
   if ($id == 14) {
-    $Bfsm = 0.;
-    $masa = $mp/1000.;
+    $BFSM = 0.;
+    $mass = $mp/1000.;
   }
   else {
-    $A=int($id/100.);
-    $Z=int($id - $A * 100.);
-    $N=$A-$Z;
+    $A = int($id / 100.);
+    $Z = int($id - $A * 100.);
+    my $N = $A - $Z;
   
-    $vol = $cv * $A; 
-    $sup = - $cs * $A**(2./3.);
-    $cou = - $cc * $Z * ($Z-1) / $A**(1./3.);
-    $asy = - $ca * (($A - 2 * $Z)**2) / $A;
-    $par = $cp / (sqrt($A));
+    my $vol = $cv * $A;
+    my $sup = - $cs * $A**(2./3.);
+    my $cou = - $cc * $Z * ($Z-1) / $A**(1./3.);
+    my $asy = - $ca * (($A - 2 * $Z)**2) / $A;
+    my $par = $cp / (sqrt($A));
   
     if (!($A%2)) {
-      if (!($Z%2)) {$par *= 1.;}
-      else {$par *= -1.;}
+      if (!($Z%2)) {
+        $par *= 1.;
+      }
+      else {
+        $par *= -1.;
+      }
     }
     else {
       $par = 0.;
     }
-    $Bfsm = $vol + $sup + $cou + $asy + $par;
-    $masa = ($N * $mn + $Z * $mp - $Bfsm)/1000.;
+    $BFSM = $vol + $sup + $cou + $asy + $par;
+    $mass = ($N * $mn + $Z * $mp - $BFSM) / 1000.;
   }
-  printf STDOUT ("%04d %.5f\n", $id, $masa);
-  $masas{$id} = $masa;
+  printf STDOUT ("%04d %.5f\n", $id, $mass);
+  $masses{$id} = $mass;
 }
-$masaId = "(0";
-$masaSt = "(0.";
+my $mass_id = "(0";
+my $mass_st = "(0.";
 
-foreach $x (sort {$a <=> $b} keys %masas) {
-  $masaId .= ", " . $x;
-  $masaSt .= ", " . $masas{$x}; 
+foreach my $x (sort {$a <=> $b} keys %masses) {
+  $mass_id .= ", " . $x;
+  $mass_st .= ", " . $masses{$x};
 }
-print STDERR "$masaId)\n";
-print STDERR "$masaSt)\n";
+print STDERR "$mass_id)\n";
+print STDERR "$mass_st)\n";

--- a/sims/sitesLago.jsonld
+++ b/sims/sitesLago.jsonld
@@ -1,0 +1,2253 @@
+{
+  "@context": {
+    "dct": "http://purl.org/dc/terms/",
+    "geo": "http://www.w3.org/2003/01/geo/wgs84_pos#",
+    "lago": "https://raw.githubusercontent.com/lagoproject/DMP/1.1/schema/lagoSchema.jsonld",
+    "@base": "https://raw.githubusercontent.com/lagoproject/DMP/1.1/defs/sitesLago.jsonld#",
+    "@vocab": "https://raw.githubusercontent.com/SEMICeu/DCAT-AP/2.0.0/releases/2.0.0/dcat-ap_2.0.0.jsonld",
+    "_dcatap": "https://raw.githubusercontent.com/SEMICeu/DCAT-AP/2.0.0/releases/2.0.0/dcat-ap_2.0.0.jsonld",
+    "_dcatap_landing_page": "http://data.europa.eu/r5r/"
+  },
+  "@graph": [
+    {
+      "@id": "and",
+      "@type": "lago:DetectorSite",
+      "name": "Andes, Argentina",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "and#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-30.19",
+        "geo:longitude": "-69.82",
+        "geo:altitude": "4200"
+      },
+      "lago:obsLev": {
+        "@default": "420000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.658",
+          "lago:bz": "-11.951",
+          "lago:bi": "23.011"
+        }
+      }
+    },
+    {
+      "@id": "asu",
+      "@type": "lago:DetectorSite",
+      "name": "Asuncion-Paraguay, Paraguay",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UNA"
+      },
+      "geometry": {
+        "@id": "asu#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-25.19",
+        "geo:longitude": "-57.3",
+        "geo:altitude": "136"
+      },
+      "lago:obsLev": {
+        "@default": "13600"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "18.233",
+          "lago:bz": "-11.73",
+          "lago:bi": "22.22"
+        }
+      }
+    },
+    {
+      "@id": "ata",
+      "@type": "lago:DetectorSite",
+      "name": "Atacama, Chile",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UVAL"
+      },
+      "geometry": {
+        "@id": "ata#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-23.005778",
+        "geo:longitude": "-67.759167",
+        "geo:altitude": "5105"
+      },
+      "lago:obsLev": {
+        "@default": "510500"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-10-28",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "20.638",
+          "lago:bz": "-8.598",
+          "lago:bi": "22.5"
+        }
+      }
+    },
+    {
+      "@id": "ber",
+      "@type": "lago:DetectorSite",
+      "name": "Berlin, Colombia",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UIS"
+      },
+      "geometry": {
+        "@id": "ber#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "7.19",
+        "geo:longitude": "-72.88",
+        "geo:altitude": "3450"
+      },
+      "lago:obsLev": {
+        "@default": "345000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.751",
+          "lago:bz": "16.029",
+          "lago:bi": "31.467"
+        }
+      }
+    },
+    {
+      "@id": "bga",
+      "@type": "lago:DetectorSite",
+      "name": "Bucaramanga, Colombia",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UIS"
+      },
+      "geometry": {
+        "@id": "bga#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "7.14",
+        "geo:longitude": "-73.12",
+        "geo:altitude": "956"
+      },
+      "lago:obsLev": {
+        "@default": "95000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.793",
+          "lago:bz": "16.055",
+          "lago:bi": "31.506"
+        }
+      }
+    },
+    {
+      "@id": "brc",
+      "@type": "lago:DetectorSite",
+      "name": "Bariloche, Argentina",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CNEA"
+      },
+      "geometry": {
+        "@id": "brc#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-41.15",
+        "geo:longitude": "-71.3",
+        "geo:altitude": "850"
+      },
+      "lago:obsLev": {
+        "@default": "86500"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E3"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "18.952",
+          "lago:bz": "-17.05",
+          "lago:bi": "25.58"
+        }
+      }
+    },
+    {
+      "@id": "bue",
+      "@type": "lago:DetectorSite",
+      "name": "Buenos Aires, Argentina",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "IAFE"
+      },
+      "geometry": {
+        "@id": "bue#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-34.54",
+        "geo:longitude": "-58.44",
+        "geo:altitude": "10"
+      },
+      "lago:obsLev": {
+        "@default": "1000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "17.09",
+          "lago:bz": "-14.673",
+          "lago:bi": "22.705"
+        }
+      }
+    },
+    {
+      "@id": "casp",
+      "@type": "lago:DetectorSite",
+      "name": "Casposo, Argentina",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "casp#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-31.22",
+        "geo:longitude": "-69.63",
+        "geo:altitude": "2600"
+      },
+      "lago:obsLev": {
+        "@default": "260000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.473",
+          "lago:bz": "-12.436",
+          "lago:bi": "23.109"
+        }
+      }
+    },
+    {
+      "@id": "cha",
+      "@type": "lago:DetectorSite",
+      "name": "Chacaltaya, Bolivia",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UMSA"
+      },
+      "geometry": {
+        "@id": "cha#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-16.35",
+        "geo:longitude": "-68.13",
+        "geo:altitude": "5230"
+      },
+      "lago:obsLev": {
+        "@default": "523000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "22.38",
+          "lago:bz": "-4.62",
+          "lago:bi": "23.112"
+        }
+      }
+    },
+    {
+      "@id": "chi",
+      "@type": "lago:DetectorSite",
+      "name": "Chimborazo, Ecuador",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "EPOCH"
+      },
+      "geometry": {
+        "@id": "chi#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-1.47",
+        "geo:longitude": "-78.82",
+        "geo:altitude": "5000"
+      },
+      "lago:obsLev": {
+        "@default": "500000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-10-28",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.56",
+          "lago:bz": "8.758",
+          "lago:bi": "28.019"
+        }
+      }
+    },
+    {
+      "@id": "chia",
+      "@type": "lago:DetectorSite",
+      "name": "Chiapas, Mexico",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UNACH"
+      },
+      "geometry": {
+        "@id": "chia#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "16.75",
+        "geo:longitude": "-93.12",
+        "geo:altitude": "522"
+      },
+      "lago:obsLev": {
+        "@default": "52200"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "27.405",
+          "lago:bz": "27.024",
+          "lago:bi": "38.497"
+        }
+      }
+    },
+    {
+      "@id": "cop",
+      "@type": "lago:DetectorSite",
+      "name": "Copahue, Argentina",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "cop#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-37.85",
+        "geo:longitude": "-71.17",
+        "geo:altitude": "2000"
+      },
+      "lago:obsLev": {
+        "@default": "200000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.04",
+          "lago:bz": "-15.493",
+          "lago:bi": "24.586"
+        }
+      }
+    },
+    {
+      "@id": "cpv",
+      "@type": "lago:DetectorSite",
+      "name": "Campina Grande, Brazil",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UFCG"
+      },
+      "geometry": {
+        "@id": "cpv#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-7.23",
+        "geo:longitude": "-35.88",
+        "geo:altitude": "550"
+      },
+      "lago:obsLev": {
+        "@default": "55000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "21.174",
+          "lago:bz": "-12.612",
+          "lago:bi": "26.025"
+        }
+      }
+    },
+    {
+      "@id": "cuz",
+      "@type": "lago:DetectorSite",
+      "name": "Cusco, Peru",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CONIDA"
+      },
+      "geometry": {
+        "@id": "cuz#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-13.52",
+        "geo:longitude": "-71.96",
+        "geo:altitude": "3400"
+      },
+      "lago:obsLev": {
+        "@default": "340000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "23.676",
+          "lago:bz": "-2.02",
+          "lago:bi": "23.905"
+        }
+      }
+    },
+    {
+      "@id": "gua",
+      "@type": "lago:DetectorSite",
+      "name": "Guatemala, Guatemala",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UVG"
+      },
+      "geometry": {
+        "@id": "gua#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "14.63",
+        "geo:longitude": "-90.59",
+        "geo:altitude": "1490"
+      },
+      "lago:obsLev": {
+        "@default": "149000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "27.532",
+          "lago:bz": "24.932",
+          "lago:bi": "37.145"
+        }
+      }
+    },
+    {
+      "@id": "ima",
+      "@type": "lago:DetectorSite",
+      "name": "Imata, Peru",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CONIDA"
+      },
+      "geometry": {
+        "@id": "ima#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-15.841",
+        "geo:longitude": "-71.091",
+        "geo:altitude": "4600"
+      },
+      "lago:obsLev": {
+        "@default": "460000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-23",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "22.969",
+          "lago:bz": "-3.79",
+          "lago:bi": "23.422"
+        }
+      }
+    },
+    {
+      "@id": "jsc",
+      "@type": "lago:DetectorSite",
+      "name": "J\u00fclich, Germany",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "jsc#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "50.92",
+        "geo:longitude": "6.54",
+        "geo:altitude": "100"
+      },
+      "lago:obsLev": {
+        "@default": "10000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.676",
+          "lago:bz": "44.928",
+          "lago:bi": "49.055"
+        }
+      }
+    },
+    {
+      "@id": "kna",
+      "@type": "lago:DetectorSite",
+      "name": "Vina Del Mar, Chile",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UVM"
+      },
+      "geometry": {
+        "@id": "kna#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-33.07",
+        "geo:longitude": "-71.55",
+        "geo:altitude": "347"
+      },
+      "lago:obsLev": {
+        "@default": "34700"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.56",
+          "lago:bz": "-13.333",
+          "lago:bi": "23.679"
+        }
+      }
+    },
+    {
+      "@id": "lim",
+      "@type": "lago:DetectorSite",
+      "name": "Lima, Peru",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CONIDA"
+      },
+      "geometry": {
+        "@id": "lim#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-12.1",
+        "geo:longitude": "-77.02",
+        "geo:altitude": "150"
+      },
+      "lago:obsLev": {
+        "@default": "16800"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "24.723",
+          "lago:bz": "-0.476",
+          "lago:bi": "24.751"
+        }
+      }
+    },
+    {
+      "@id": "lpb",
+      "@type": "lago:DetectorSite",
+      "name": "La Paz, Bolivia",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UMSA"
+      },
+      "geometry": {
+        "@id": "lpb#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-16.49",
+        "geo:longitude": "-68.15",
+        "geo:altitude": "3630"
+      },
+      "lago:obsLev": {
+        "@default": "363000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "22.362",
+          "lago:bz": "-4.708",
+          "lago:bi": "23.109"
+        }
+      }
+    },
+    {
+      "@id": "lsc",
+      "@type": "lago:DetectorSite",
+      "name": "La Serena, Chile",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "USERENA"
+      },
+      "geometry": {
+        "@id": "lsc#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-29.9",
+        "geo:longitude": "-71.25",
+        "geo:altitude": "28"
+      },
+      "lago:obsLev": {
+        "@default": "2800"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.975",
+          "lago:bz": "-11.826",
+          "lago:bi": "23.213"
+        }
+      }
+    },
+    {
+      "@id": "mad",
+      "@type": "lago:DetectorSite",
+      "name": "MAD, Spain",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "mad#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "40.5",
+        "geo:longitude": "-3.67",
+        "geo:altitude": "700"
+      },
+      "lago:obsLev": {
+        "@default": "70000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "25.647",
+          "lago:bz": "36.933",
+          "lago:bi": "44.965"
+        }
+      }
+    },
+    {
+      "@id": "mapi",
+      "@type": "lago:DetectorSite",
+      "name": "Machu Picchu, Antarctica",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CONIDA"
+      },
+      "geometry": {
+        "@id": "mapi#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-62.09",
+        "geo:longitude": "-58.47",
+        "geo:altitude": "10"
+      },
+      "lago:obsLev": {
+        "@default": "1000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E5"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.309",
+          "lago:bz": "-28.693",
+          "lago:bi": "34.763"
+        }
+      }
+    },
+    {
+      "@id": "mge",
+      "@type": "lago:DetectorSite",
+      "name": "Malargue, Argentina",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CNEA"
+      },
+      "geometry": {
+        "@id": "mge#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-35.45",
+        "geo:longitude": "-69.57",
+        "geo:altitude": "1450"
+      },
+      "lago:obsLev": {
+        "@default": "145000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "18.987",
+          "lago:bz": "-14.326",
+          "lago:bi": "23.79"
+        }
+      }
+    },
+    {
+      "@id": "pam",
+      "@type": "lago:DetectorSite",
+      "name": "Pamplona, Colombia",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UNIPAM"
+      },
+      "geometry": {
+        "@id": "pam#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "7.22",
+        "geo:longitude": "-72.39",
+        "geo:altitude": "2342"
+      },
+      "lago:obsLev": {
+        "@default": "234200"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.743",
+          "lago:bz": "15.955",
+          "lago:bi": "31.443"
+        }
+      }
+    },
+    {
+      "@id": "ppet",
+      "@type": "lago:DetectorSite",
+      "name": "Peteroa, Argentina",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "ppet#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-35.25",
+        "geo:longitude": "-70.57",
+        "geo:altitude": "3500"
+      },
+      "lago:obsLev": {
+        "@default": "350000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.139",
+          "lago:bz": "-14.27",
+          "lago:bi": "23.883"
+        }
+      }
+    },
+    {
+      "@id": "psnc",
+      "@type": "lago:DetectorSite",
+      "name": "Poznam, Poland",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "psnc#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "52.41",
+        "geo:longitude": "16.92",
+        "geo:altitude": "100"
+      },
+      "lago:obsLev": {
+        "@default": "10000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "18.598",
+          "lago:bz": "46.45",
+          "lago:bi": "50.066"
+        }
+      }
+    },
+    {
+      "@id": "quie",
+      "@type": "lago:DetectorSite",
+      "name": "Quito-EPN, Ecuador",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "EPN"
+      },
+      "geometry": {
+        "@id": "quie#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-0.2",
+        "geo:longitude": "-78.5",
+        "geo:altitude": "2850"
+      },
+      "lago:obsLev": {
+        "@default": "285000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.717",
+          "lago:bz": "9.971",
+          "lago:bi": "28.579"
+        }
+      }
+    },
+    {
+      "@id": "sac",
+      "@type": "lago:DetectorSite",
+      "name": "San Antonio de los Cobres, Argentina",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "CNEA"
+      },
+      "geometry": {
+        "@id": "sac#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-24.71",
+        "geo:longitude": "-66.38",
+        "geo:altitude": "4820"
+      },
+      "lago:obsLev": {
+        "@default": "482000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "20.06",
+          "lago:bz": "-9.616",
+          "lago:bi": "22.398"
+        }
+      }
+    },
+    {
+      "@id": "sao",
+      "@type": "lago:DetectorSite",
+      "name": "Sao Paulo-UFABC, Brazil",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UFABC"
+      },
+      "geometry": {
+        "@id": "sao#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-23.38",
+        "geo:longitude": "-46.31",
+        "geo:altitude": "760"
+      },
+      "lago:obsLev": {
+        "@default": "76000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "16.484",
+          "lago:bz": "-14.48",
+          "lago:bi": "22.905"
+        }
+      }
+    },
+    {
+      "@id": "sawb",
+      "@type": "lago:DetectorSite",
+      "name": "Marambio, Antarctica",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UBA"
+      },
+      "geometry": {
+        "@id": "sawb#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-64.24",
+        "geo:longitude": "-56.62",
+        "geo:altitude": "200"
+      },
+      "lago:obsLev": {
+        "@default": "20000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E5"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.366",
+          "lago:bz": "-30.222",
+          "lago:bi": "36.077"
+        }
+      }
+    },
+    {
+      "@id": "serb",
+      "@type": "lago:DetectorSite",
+      "name": "Riobamba-EPOSCH, Ecuador",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "EPOCH"
+      },
+      "geometry": {
+        "@id": "serb#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-1.81",
+        "geo:longitude": "-78.74",
+        "geo:altitude": "2750"
+      },
+      "lago:obsLev": {
+        "@default": "275000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.577",
+          "lago:bz": "8.499",
+          "lago:bi": "27.952"
+        }
+      }
+    },
+    {
+      "@id": "sgd",
+      "@type": "lago:DetectorSite",
+      "name": "Sierra Grande, Argentina",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "sgd#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-41.668",
+        "geo:longitude": "-65.365",
+        "geo:altitude": "250"
+      },
+      "lago:obsLev": {
+        "@default": "25000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-06-02",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "18.108",
+          "lago:bz": "-16.917",
+          "lago:bi": "24.785"
+        }
+      }
+    },
+    {
+      "@id": "sng",
+      "@type": "lago:DetectorSite",
+      "name": "Sierra Negra, Mexico",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "BUAP"
+      },
+      "geometry": {
+        "@id": "sng#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "18.16",
+        "geo:longitude": "-97.95",
+        "geo:altitude": "4550"
+      },
+      "lago:obsLev": {
+        "@default": "455000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "27.358",
+          "lago:bz": "28.038",
+          "lago:bi": "39.217"
+        }
+      }
+    },
+    {
+      "@id": "sudb",
+      "@type": "lago:DetectorSite",
+      "name": "Chreighton, Canada",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "sudb#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "46.46",
+        "geo:longitude": "-81.17",
+        "geo:altitude": "2100"
+      },
+      "lago:obsLev": {
+        "@default": "210000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "17.037",
+          "lago:bz": "51.991",
+          "lago:bi": "54.79"
+        }
+      }
+    },
+    {
+      "@id": "tac",
+      "@type": "lago:DetectorSite",
+      "name": "Tacana, Guatemala",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UVG"
+      },
+      "geometry": {
+        "@id": "tac#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "15.13",
+        "geo:longitude": "-92.11",
+        "geo:altitude": "4060"
+      },
+      "lago:obsLev": {
+        "@default": "406000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "27.53",
+          "lago:bz": "25.353",
+          "lago:bi": "37.432"
+        }
+      }
+    },
+    {
+      "@id": "truj",
+      "@type": "lago:DetectorSite",
+      "name": "Trujillo, Spain",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "truj#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "39.47",
+        "geo:longitude": "-5.88",
+        "geo:altitude": "560"
+      },
+      "lago:obsLev": {
+        "@default": "56000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "26.223",
+          "lago:bz": "35.844",
+          "lago:bi": "44.413"
+        }
+      }
+    },
+    {
+      "@id": "tuc",
+      "@type": "lago:DetectorSite",
+      "name": "Tucuman, Argentina",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UNT"
+      },
+      "geometry": {
+        "@id": "tuc#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-26.5",
+        "geo:longitude": "-65.11",
+        "geo:altitude": "430"
+      },
+      "lago:obsLev": {
+        "@default": "43000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.487",
+          "lago:bz": "-10.647",
+          "lago:bi": "22.365"
+        }
+      }
+    },
+    {
+      "@id": "vcp",
+      "@type": "lago:DetectorSite",
+      "name": "Campinas, Brazil",
+      "lago:belongsLago": true,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": "UNICAMP"
+      },
+      "geometry": {
+        "@id": "vcp#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-22.9",
+        "geo:longitude": "-47.06",
+        "geo:altitude": "640"
+      },
+      "lago:obsLev": {
+        "@default": "64000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E1"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-04-08",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "16.751",
+          "lago:bz": "-14.104",
+          "lago:bi": "22.873"
+        }
+      }
+    },
+    {
+      "@id": "viri",
+      "@type": "lago:DetectorSite",
+      "name": "Villa Rica, Chile",
+      "lago:belongsLago": false,
+      "qualifiedAttribution": {
+        "@type": "lago:Organisation",
+        "name": ""
+      },
+      "geometry": {
+        "@id": "viri#geometry",
+        "@type": "geo:Point",
+        "geo:latitude": "-39.42",
+        "geo:longitude": "-71.94",
+        "geo:altitude": "2850"
+      },
+      "lago:obsLev": {
+        "@default": "285000"
+      },
+      "lago:atmcrd": {
+        "@type": {
+          "@default": "lago:Atmod"
+        },
+        "lago:modatm": {
+          "@default": "E2"
+        }
+      },
+      "lago:magnet": {
+        "@default": {
+          "lago:bDate": "2021-05-18",
+          "conformsTo": {
+            "@id": "https://doi.org/10.1186/s40623-020-01288-x",
+            "@type": [
+              "dct:Standard",
+              "DataSet"
+            ],
+            "title": "IGRF",
+            "description": "International Geomagnetic Reference Field",
+            "landingpage": "https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html",
+            "version": "13",
+            "dataservice": {
+              "title": "Geomagnetic Model Web Service",
+              "endpointURL": "http://geomag.bgs.ac.uk/web_service/GMModels/"
+            },
+            "temporalCoverage": {
+              "startDate": "2020-01-01",
+              "endDate": "2024-12-31"
+            },
+            "temporalResolution": "P1D"
+          },
+          "lago:bx": "19.061",
+          "lago:bz": "-16.289",
+          "lago:bi": "25.148"
+        }
+      }
+    }
+  ]
+}

--- a/sims/test-json.pl
+++ b/sims/test-json.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings FATAL => 'all';
+use LWP::Simple;
+use JSON;
+
+# read sitesLago.jsonld from LAGO DMP and obtain predefined site characteristics.
+my $url="https://lagoproject.github.io/DMP/defs/sitesLago.jsonld";
+my $jsonld;
+die "could not get $url\n" unless (defined($jsonld = get $url));
+my $decoded = decode_json($jsonld);
+my @sites_json = @{ $decoded->{'@graph'} };
+my %sites = ();
+my $n = 0;
+foreach my $s ( @sites_json ) {
+    $sites { $s->{'@id'} } = [
+        $s->{'lago:atmcrd'}{'lago:modatm'}{'@default'},
+        $s->{'lago:obsLev'}{'@default'},
+        $s->{'lago:magnet'}{'@default'}{'lago:bx'},
+        $s->{'lago:magnet'}{'@default'}{'lago:bz'}
+    ];
+    $n++;
+}
+print("$n\n");
+foreach my $s ( keys %sites ) {
+    print "$s: @{ $sites{$s} }\n";
+}
+my $tst = "and";
+if (defined $sites{"$tst"}) {
+    print "$tst: @{ $sites{$tst} }\n";
+} else {
+    print "$tst not found\n";
+}


### PR DESCRIPTION
- generate_spectra.pl and rain.pl: Now they download [lagoSites.jsonld](https://lagoproject.github.io/DMP/defs/sitesLago/#defined-lago-sites) from the LAGO [LAGO DMP](https://lagoproject.github.io/DMP/DMP/) and parses the jsonld definitions to obtain the current defaults for all the LAGO sites (atmospheric model, altitude and geomagnetic field). 
- Code uniformization, updated copyrights and licenses at all the codes and scripts
- New pragmas added: strict and warnings.
- Prepared to tag the new version 1.9.   